### PR TITLE
[#35] Add sleeps for mtime checks (4-2-stable)

### DIFF
--- a/packaging/test_rule_engine_plugin_hard_links.py
+++ b/packaging/test_rule_engine_plugin_hard_links.py
@@ -45,6 +45,7 @@ class Test_Rule_Engine_Plugin_Hard_Links(session.make_sessions_mixin(admins, use
 
             # Capture the current mtime of the parent collection.
             old_mtime = self.get_collection_mtime(self.user.session_collection)
+            sleep(1)
 
             # Create a hard link.
             hard_link = os.path.join(self.user.session_collection, 'foo.0')
@@ -240,6 +241,7 @@ class Test_Rule_Engine_Plugin_Hard_Links(session.make_sessions_mixin(admins, use
                 self.assertTrue(self.hard_link_count(hl_info['uuid'], hl_info['resource_id']) == count)
                 collection = os.path.dirname(path)
                 old_mtime = self.get_collection_mtime(collection)
+                sleep(1)
                 self.admin.assert_icommand(['irm', '-f', path], 'STDOUT', ['deprecated'])
                 self.assertNotEqual(old_mtime, self.get_collection_mtime(collection))
                 count -= 1
@@ -458,6 +460,7 @@ class Test_Rule_Engine_Plugin_Hard_Links(session.make_sessions_mixin(admins, use
                 # collection to be updated.
                 parent_collection = os.path.dirname(data_object)
                 old_mtime = self.get_collection_mtime(parent_collection)
+                sleep(1)
 
                 # Rename the original data object and show that only the logical path changed.
                 # Hard Links never modify the physical path of any data objects.


### PR DESCRIPTION
The parent collection mtimes were not being updated to a new time in the test suite because the query for the collection mtime and the rule creating a hard link were running inside the same second. As such, the collection mtime is in fact updated but the value does not change. Adding a sleep after the query for the original collection mtime fixes this and the CI tests pass.